### PR TITLE
Added a test demonstrating the inability to import files only containing types

### DIFF
--- a/fixtures/imports-only-types-only/a.graphql
+++ b/fixtures/imports-only-types-only/a.graphql
@@ -1,0 +1,4 @@
+type A {
+  first: String
+  second: Float
+}

--- a/fixtures/imports-only-types-only/all.graphql
+++ b/fixtures/imports-only-types-only/all.graphql
@@ -1,0 +1,2 @@
+# import * from 'a.graphql'
+# import * from 'b.graphql'

--- a/fixtures/imports-only-types-only/b.graphql
+++ b/fixtures/imports-only-types-only/b.graphql
@@ -1,0 +1,3 @@
+type B {
+  hello: String!
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -76,6 +76,21 @@ type Query {
   t.is(importSchema('fixtures/imports-only/all.graphql'), expectedSDL)
 })
 
+test('importSchema: imports only types only', t => {
+  const expectedSDL = `\
+type A {
+  first: String
+  second: Float
+}
+
+type B {
+  hello: String!
+}
+`
+
+  t.is(importSchema('fixtures/imports-only-types-only/all.graphql'), expectedSDL)
+})
+
 test('importSchema: field types', t => {
   const expectedSDL = `\
 type A {


### PR DESCRIPTION
That is types that aren't referenced in other files. I feel like that is a bit of an oversight. Shouldn't they at least be dumped at the bottom? Obviously in any normal scenario it wouldn't make sense to have types that aren't at least referenced by the `Query` or `Mutation` types, but in the case of intermediate processing similar to what Prisma does, I'd think this would be preferable.