### PR TITLE
fix(nested importing)

### DIFF
--- a/fixtures/import-nested/a.graphql
+++ b/fixtures/import-nested/a.graphql
@@ -1,0 +1,3 @@
+# import Query.first, Query.second from "c.graphql"
+
+type Query

--- a/fixtures/import-nested/all.graphql
+++ b/fixtures/import-nested/all.graphql
@@ -1,0 +1,4 @@
+# import Query.first, Query.second from "a.graphql"
+# import Query.third from "b.graphql"
+
+type Query

--- a/fixtures/import-nested/b.graphql
+++ b/fixtures/import-nested/b.graphql
@@ -1,0 +1,3 @@
+# import Query.third from "c.graphql"
+
+type Query

--- a/fixtures/import-nested/c.graphql
+++ b/fixtures/import-nested/c.graphql
@@ -1,0 +1,6 @@
+type Query {
+  first: String
+  second: Float
+  third: String
+  unused: String
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -87,6 +87,17 @@ type Query {
   t.is(importSchema('fixtures/import-duplicate/all.graphql'), expectedSDL)
 })
 
+test('importSchema: import nested', t => {
+  const expectedSDL = `\
+type Query {
+  first: String
+  second: Float
+  third: String
+}
+`
+  t.is(importSchema('fixtures/import-nested/all.graphql'), expectedSDL)
+})
+
 test('importSchema: field types', t => {
   const expectedSDL = `\
 type A {


### PR DESCRIPTION
Previously only the files that were processed were kept in memory in a `Set`, to prevent circular dependencies. However, it can happen that a file gets imported two or more times, with different imports. To fix this, instead of only keeping track of the processed files, it now also keeps track of which specific imports from the processed files are used.

The new test I added illustrates this use-case. This might seem like a far stretch, but if you use Prisma and have separated files, e.g. "user.graphql" and "restaurant.graphql", and use each file to import specific types from "generated/prisma.graphql", you'll walk into this.

It cost me three hours to finally end up with a solution that is less code than before, so I'm very happy with that if I may say so 😅.

## An explanation with examples

This is the use-case I'm fixing:

**`schema.graphql`**

```graphql
# import Query.*, Mutation.*, * from "./restaurant.graphql"
# import Query.*, Mutation.*, * from "./user.graphql"
```

**`restaurant.graphql`**

```graphql
# import Query.restaurant, Mutation.createRestaurant from "./prisma.graphql"
```


**`user.graphql`**

```graphql
# import Query.user, Mutation.createUser from "./prisma.graphql"
```

**Actual result**

Only `Query.restaurant` and `Mutation.createRestaurant` get imported, `Query.user` and `Mutation.createUser` are ignored.

**Expected result**

`Query.restaurant`, `Mutation.createRestaurant`, `Query.user` and `Mutation.createUser` are imported.