### PR TITLE
Support for node_modules in graphql imports, attempt 2

### DIFF
--- a/fixtures/import-module/a.graphql
+++ b/fixtures/import-module/a.graphql
@@ -1,0 +1,6 @@
+# import B from 'graphql-import-test/b.graphql'
+
+type A {
+  id: ID!
+  author: B!
+}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/graphql": "0.12.6",
     "@types/lodash": "4.14.116",
     "@types/node": "9.6.27",
+    "@types/resolve-from": "0.0.18",
     "ava": "0.25.0",
     "ava-ts": "0.25.0",
     "graphql": "0.13.2",
@@ -53,6 +54,7 @@
     "typescript": "2.8.3"
   },
   "dependencies": {
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "resolve-from": "^4.0.0"
   }
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -75,7 +75,7 @@ test('parse: multi line import', t => {
 
 test('Module in node_modules', t => {
   const b = `\
-# import lower from './lowerf.graphql'
+# import lower from './lower.graphql'
 type B {
   id: ID!
   nickname: String! @lower

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,5 @@
 import test from 'ava'
+import * as fs from 'fs'
 import { parseImportLine, parseSDL, importSchema } from '.'
 
 test('parseImportLine: parse single import', t => {
@@ -44,6 +45,13 @@ test('parseImportLine: different path', t => {
   })
 })
 
+test('parseImportLine: module in node_modules', t => {
+  t.deepEqual(parseImportLine(`import A from "module-name"`), {
+    imports: ['A'],
+    from: 'module-name',
+  })
+})
+
 test('parseSDL: non-import comment', t => {
   t.deepEqual(parseSDL(`#importent: comment`), [])
 })
@@ -63,6 +71,39 @@ test('parse: multi line import', t => {
       from: 'b.graphql',
     },
   ])
+})
+
+test('Module in node_modules', t => {
+  const b = `\
+# import lower from './lowerf.graphql'
+type B {
+  id: ID!
+  nickname: String! @lower
+}
+`
+  const lower = `\
+directive @lower on FIELD_DEFINITION
+`
+  const expectedSDL = `\
+type A {
+  id: ID!
+  author: B!
+}
+
+type B {
+  id: ID!
+  nickname: String! @lower
+}
+
+directive @lower on FIELD_DEFINITION
+`
+  const moduleDir = 'node_modules/graphql-import-test'
+  if (!fs.existsSync(moduleDir)) {
+    fs.mkdirSync(moduleDir)
+  }
+  fs.writeFileSync(moduleDir + '/b.graphql', b)
+  fs.writeFileSync(moduleDir + '/lower.graphql', lower)
+  t.is(importSchema('fixtures/import-module/a.graphql'), expectedSDL)
 })
 
 test('importSchema: imports only', t => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
 } from 'graphql'
 import { flatten, groupBy, includes, keyBy } from 'lodash'
 import * as path from 'path'
+import * as resolveFrom from 'resolve-from'
 
 import { completeDefinitionPool, ValidDefinitionNode } from './definition'
 
@@ -165,6 +166,29 @@ function isEmptySDL(sdl: string): boolean {
 }
 
 /**
+ * Resolve the path of an import.
+ * First it will try to find a file relative from the file the import is in, if that fails it will try to resolve it as a module so imports from packages work correctly.
+ *
+ * @param filePath Path the import was made from
+ * @param importFrom Path given for the import
+ * @returns Full resolved path to a file
+ */
+function resolveModuleFilePath(filePath: string, importFrom: string): string {
+  const dirname = path.dirname(filePath)
+  if (isFile(filePath) && isFile(importFrom)) {
+    try {
+      return fs.realpathSync(path.join(dirname, importFrom))
+    } catch (e) {
+      if (e.code === 'ENOENT') {
+        return resolveFrom(dirname, importFrom)
+      }
+    }
+  }
+
+  return importFrom
+}
+
+/**
  * Recursively process all schema files. Keeps track of both the filtered
  * type definitions, and all type definitions, because they might be needed
  * in post-processing (to add missing types)
@@ -190,7 +214,6 @@ function collectDefinitions(
   typeDefinitions: ValidDefinitionNode[][]
 } {
   const key = isFile(filePath) ? path.resolve(filePath) : filePath
-  const dirname = path.dirname(filePath)
 
   // Get TypeDefinitionNodes from current schema
   const document = getDocumentFromSDL(sdl)
@@ -228,10 +251,7 @@ function collectDefinitions(
   // Process each file (recursively)
   mergedModules.forEach(m => {
     // If it was not yet processed (in case of circular dependencies)
-    const moduleFilePath =
-      isFile(filePath) && isFile(m.from)
-        ? path.resolve(path.join(dirname, m.from))
-        : m.from
+    const moduleFilePath = resolveModuleFilePath(filePath, m.from)
     if (!processedFiles.has(moduleFilePath)) {
       collectDefinitions(
         m.imports,


### PR DESCRIPTION
This is a continuation of PR #136 from @lfades (spoke to @lfades about this and he was okay with it).

It uses `resolve-from` instead of `require.resolve` with the `paths` option because it is not compatible with Node < 8.

Also I think this one works a bit differently; it doesn't introduce a breaking change since it will first try to look up the path relative to the file the import is in, and only if that fails it will use `resolve-from`.

Fixes #57